### PR TITLE
Add :poolboy as an application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Geolix.Mixfile do
   end
 
   def application do
-    [ applications: [ :logger ],
+    [ applications: [ :logger, :poolboy ],
       mod:          { Geolix, [] } ]
   end
 

--- a/verify/geolix/lib/mix/tasks/geolix/verify.ex
+++ b/verify/geolix/lib/mix/tasks/geolix/verify.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Geolix.Verify do
   @results   [ @data_path, "geolix_results.txt" ] |> Path.join() |> Path.expand()
 
   def run(_args) do
-    :ok         = Application.start(:geolix)
+    { :ok, _ }  = Application.ensure_all_started(:geolix)
     result_file = @results |> File.open!([ :write, :utf8 ])
 
     @ip_set


### PR DESCRIPTION
Per https://hexdocs.pm/exrm/extra-common-issues.html, this is causing issue when using Exrm to package a release. The current workaround is to add :poolboy to your own application list, but it would be better to have it covered in the main geolix repo :)

