### PR TITLE
Read from a remote file

### DIFF
--- a/lib/geolix/reader.ex
+++ b/lib/geolix/reader.ex
@@ -17,6 +17,17 @@ defmodule Geolix.Reader do
     |> maybe_succeed()
   end
 
+  @doc """
+  Handles remote binary data and returns the data and metadata parts from it.
+  """
+  @spec handle_binary(Binary.t, String.t) :: { binary | :error, binary | :no_metadata }
+  def handle_binary(binary, filename) do
+    binary
+    |> maybe_gunzip(filename)
+    |> :binary.split(@metadata_marker)
+    |> maybe_succeed()
+  end
+
   defp maybe_gunzip(data, filename) do
     case String.ends_with?(filename, ".gz") do
       true  -> :zlib.gunzip(data)

--- a/test/geolix/database/loader_test.exs
+++ b/test/geolix/database/loader_test.exs
@@ -31,4 +31,11 @@ defmodule Geolix.Database.LoaderTest do
     assert :ok = Geolix.set_database(:system_env, { :system, var })
     assert %Result.City{} = Geolix.lookup("2.125.160.216", where: :system_env)
   end
+
+  test "remote database" do
+    remote_db = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz"
+
+    assert :ok = Geolix.set_database(:reload, remote_db)
+    assert %Result.Country{} = Geolix.lookup("2.125.160.216", where: :reload)
+  end
 end


### PR DESCRIPTION
This [long-awaited PR](https://github.com/mneudert/geolix/pull/9#issuecomment-198930110) supports the ability to read `.mmdb` and `.mmdb.gz` files from a remote address rather on your local file system.